### PR TITLE
aws sdk 1.11.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ subprojects {
   }
 
   dependencies {
-    compile 'com.amazonaws:aws-java-sdk:1.11.0'
+    compile 'com.amazonaws:aws-java-sdk:1.11.1'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.5.5'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'

--- a/gradle/awsMixin.gradle
+++ b/gradle/awsMixin.gradle
@@ -19,7 +19,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.amazonaws:aws-java-sdk:1.11.0'
+    classpath 'com.amazonaws:aws-java-sdk:1.11.1'
     classpath 'com.google.guava:guava:18.0'
   }
 }


### PR DESCRIPTION
Update to 1.11.1. There is already a 1.11.2, but
using this version first to verify the release
process via the travis build.