### PR TITLE
add license header to generated files

### DIFF
--- a/gradle/awsMixin.gradle
+++ b/gradle/awsMixin.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Netflix, Inc.
+ * Copyright 2014-2016 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -249,7 +249,26 @@ class AwsMixinGenerator implements Plugin<Project> {
     })
   }
 
+  def licenseHeader = """\
+/*
+ * Copyright 2014-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"""
+
   def mapperHeader = """\
+$licenseHeader
 package com.netflix.awsobjectmapper;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -270,6 +289,7 @@ public class AmazonObjectMapper extends ObjectMapper {
 """
 
   def mixinHeader = """\
+$licenseHeader
 package com.netflix.awsobjectmapper;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -278,6 +298,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 """
 
   def strategyHeader = """\
+$licenseHeader
 package com.netflix.awsobjectmapper;
 
 import com.fasterxml.jackson.databind.cfg.MapperConfig;


### PR DESCRIPTION
This is mostly to get rid of the noise from all
"missing header" warnings in the build output.