### PR TITLE
change aws-java-sdk to be provided

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
   }
 
   dependencies {
-    provided 'com.amazonaws:aws-java-sdk:1.11.28'
+    provided 'com.amazonaws:aws-java-sdk:1.11.29'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.6'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 
 plugins {
   id 'nebula.netflixoss' version '3.4.0'
+  id 'nebula.provided-base' version '3.1.0'
 }
 
 // Establish version and status
@@ -14,6 +15,7 @@ ext.githubProjectName = 'awsobjectmapper'
 
 allprojects {
   apply plugin: 'nebula.netflixoss'
+  apply plugin: 'nebula.provided-base'
   apply plugin: 'java'
   apply plugin: 'idea'
 }
@@ -37,7 +39,7 @@ subprojects {
   }
 
   dependencies {
-    compile 'com.amazonaws:aws-java-sdk:1.11.28'
+    provided 'com.amazonaws:aws-java-sdk:1.11.28'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.6'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'


### PR DESCRIPTION
Currently this module depends on the aws-java-sdk root
project that brings in 70+ sub-jars for various services.
In most cases a particular user will only need a small
subset of these jars.

With this change the aws-java-sdk is now provided so the
user would be expected to explicitly depend on the jars
for the services they need. In general that should already
be the case because the user should have a direct dependency
if they are using the model objects needed to work with
these mappers.

One downside to this change is the user will likely need
to be more diligent about ensuring that the awsobjectmapper
version matches the aws-java-sdk version.

@cfieber let me know if you have any concerns.