### PR TITLE
Update AWS Java SDK to latest (1.11.83)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
 
   dependencies {
     resolutionRules 'com.netflix.nebula:gradle-resolution-rules:0.32.1'
-    compile 'com.amazonaws:aws-java-sdk:1.11.49'
+    compile 'com.amazonaws:aws-java-sdk:1.11.83'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.3'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'


### PR DESCRIPTION
I'm doing some testing of this in Spinnaker (have a couple minor issues to resolve that are due to new fields in a couple things, but those look entirely like our fault not any issues with bumping the SDK version here)