### PR TITLE
Update AWS Java SDK to 1.11.90

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
 
   dependencies {
     resolutionRules 'com.netflix.nebula:gradle-resolution-rules:0.32.1'
-    compile 'com.amazonaws:aws-java-sdk:1.11.83'
+    compile 'com.amazonaws:aws-java-sdk:1.11.90'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.3'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'


### PR DESCRIPTION
Doing some work in Spinnaker that is pushing up to update to a newer, although not newest (1.11.93) version of the AWS SDK.