### PR TITLE
aws-java-sdk 1.11.162

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
 
   dependencies {
     resolutionRules 'com.netflix.nebula:gradle-resolution-rules:0.48.0'
-    compile 'com.amazonaws:aws-java-sdk:1.11.158'
+    compile 'com.amazonaws:aws-java-sdk:1.11.162'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.7'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'


### PR DESCRIPTION
Update to version that supports target tracking (first
added in aws-java-sdk 1.6.1):

* https://aws.amazon.com/blogs/aws/new-target-tracking-policies-for-ec2-auto-scaling/
* https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#auto-scaling

/cc @anotherchrisberry 