### PR TITLE
update aws-java-sdk to 1.11.185

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
 
   dependencies {
     resolutionRules 'com.netflix.nebula:gradle-resolution-rules:0.48.0'
-    compile 'com.amazonaws:aws-java-sdk:1.11.173'
+    compile 'com.amazonaws:aws-java-sdk:1.11.185'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.7'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'


### PR DESCRIPTION
AWS SDK 1.11.185 adds support for `CidrBlockAssociationSet` to the describe-vpcs call.