### PR TITLE
Request to pickup latest AWS SDK - aws-java-sdk 1.11.356

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
 
   dependencies {
     resolutionRules 'com.netflix.nebula:gradle-resolution-rules:0.48.0'
-    compile 'com.amazonaws:aws-java-sdk:1.11.339'
+    compile 'com.amazonaws:aws-java-sdk:1.11.356'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'


### PR DESCRIPTION
Requesting to pick up latest AWS SDK as CDE team is getting into version issues