### PR TITLE
update to 1.11.469

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
   }
 
   dependencies {
-    compile 'com.amazonaws:aws-java-sdk:1.11.435'
+    compile 'com.amazonaws:aws-java-sdk:1.11.469'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.9.7'
     testCompile 'junit:junit:4.10'
     testCompile 'com.google.guava:guava:18.0'


### PR DESCRIPTION
The size of the configure method grew to large causing
compilation errors:

```
generated/com/netflix/awsobjectmapper/AmazonObjectMapperConfigurer.java:32: error: code too large
public static void configure(ObjectMapper objectMapper) {
                   ^
```

For now we just put in a pattern to ignore some of the
services we do not use that generate a lot of mixins.
Ideally it will get refactored later to generate the
method differently so we avoid the limit.