### PR TITLE
ignore deprecated accessor methods

### DIFF
--- a/buildSrc/src/main/groovy/AwsMixinGenerator.groovy
+++ b/buildSrc/src/main/groovy/AwsMixinGenerator.groovy
@@ -96,6 +96,7 @@ class AwsMixinGenerator implements Plugin<Project> {
   // Rules:
   // 1. getFoo should be ignored if isFoo is present
   // 2. setFoo(FooEnum) should be ignored, use setFoo(String s)
+  // 3. Deprecated methods should be ignored
   private List<String> methodsToAnnotate(Class<?> c) {
     List<String> anno = new ArrayList<String>()
     Set<String> methods = new HashSet<String>()
@@ -107,6 +108,8 @@ class AwsMixinGenerator implements Plugin<Project> {
         String ptype = it.parameterTypes[0].name;
         anno.add("@JsonIgnore void ${it.name}(${ptype} v);")
         anno.add("@JsonProperty void ${it.name}(String v);")
+      } else if (it.name.startsWith("get") && it.getAnnotation(Deprecated.class) != null) {
+        anno.add("@JsonIgnore ${methodString(it)};")
       } else if (prohibited.contains(it.name)) {
         anno.add("@JsonIgnore ${methodString(it)};")
       }


### PR DESCRIPTION
Some model objects, like `IpPermission`, have multiple setters
and getters, but the deprecated version only has a subset of
the information. When serializing to JSON both are written out
based on the name of the getter, but depending on which one
is read in first, the deserialized result may be missing some
attributes. With `IpPermission` the issue is `getIpRanges` and
`getIpv4Ranges`. The `getIpRanges` call expects strings, but
internally maps to an `IpRange` object. If it is used last
when deserializing then the `description` field will be missing.