### PR TITLE
Use nebula.netflixoss 8.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.netflixoss' version '8.4.1'
+  id 'nebula.netflixoss' version '8.4.2'
 }
 
 // Establish version and status


### PR DESCRIPTION
Fixes lazy task configuration 

```
* What went wrong:
An exception occurred applying plugin request [id: 'nebula.netflixoss', version: '8.4.1']
> Failed to apply plugin [class 'nebula.plugin.netflixossproject.publishing.PublishingPlugin']
   > Could not create task ':publishPackageToBintray'.
      > DefaultTaskContainer#NamedDomainObjectProvider.configure(Action) on task set cannot be executed in the current context.
```