### PR TITLE
Upgrade nebula netflixoss to 8.8.0 and gradle 6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.netflixoss' version '8.6.0'
+  id 'nebula.netflixoss' version '8.8.0'
 }
 
 // Establish version and status

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hi @brharrington 

I checked with jfrog side and it seems that the package name got misconfigured again.

I changed the `netflixoss` plugin to always use lowercase for package name to avoid issues in the future and renamed the package on bintray so it should be fine from now on

cc @OdysseusLives @chali 