### PR TITLE
nebula.netflixoss 8.8.1 forces package name to always be lowercase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-  id 'nebula.netflixoss' version '8.8.0'
+  id 'nebula.netflixoss' version '8.8.1'
 }
 
 // Establish version and status


### PR DESCRIPTION
Hi @brharrington 

I changed the underlying plugins to always force lowercase for package name to avoid the issues in the future

If this fails again, I'll place another report with jfrog as that would be on their side.

Wonderi f you could do a test release