### PR TITLE
bump aws-java-sdk to 1.12.100

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ subprojects {
   }
 
   ext {
-    awsSdkVersion = '1.12.84'
+    awsSdkVersion = '1.12.100'
   }
 
   dependencies {


### PR DESCRIPTION
Similar to https://github.com/Netflix/AWSObjectMapper/pull/107, I'd like to bump the aws sdk here to use in https://github.com/spinnaker/kork.  I'm choosing the version that [spectator uses](https://github.com/Netflix/spectator/blob/0f81569ebadf0fbdef0fd82616f6208846ee0a69/dependencies.properties#L2) to make it easier to update the version of spectator in kork.  There are no doubt other ways to handle this, with exclusions and other gradle dancing in kork, or potentially teaching spectator to publish a bom, but this is a way to move forward in the meantime.

Thanks for your help.
